### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Test And Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/colinxu2020/slhdsa/security/code-scanning/3](https://github.com/colinxu2020/slhdsa/security/code-scanning/3)

To fix the problem, we should explicitly restrict the `GITHUB_TOKEN` permissions instead of relying on inherited defaults. The least-privilege, generally safe baseline for CI jobs that only need to read the repository is `contents: read`. For this workflow, the `test`, `build_optimized`, and `build_unoptimized` jobs only check out code, run tests/builds, and upload artifacts; they do not push commits, modify releases, or interact with issues/PRs. The `upload_pypi` job already has a job-level `permissions` block (`id-token: write`) so it is not problematic and will override any workflow-level defaults.

The single best way to fix this without altering functionality is to add a workflow-root `permissions` block setting `contents: read`. This will apply to all jobs that do not define their own permissions, namely `test`, `build_optimized`, and `build_unoptimized`. The `upload_pypi` job will continue to use its own `permissions` block as defined. No additional imports or dependencies are required, and we do not need to change any steps. Concretely, insert:

```yaml
permissions:
  contents: read
```

between the `name: Test And Build` line (line 4) and the `on:` section (line 6) in `.github/workflows/ci.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
